### PR TITLE
feat(rvnklore): v1.0.21 — delete cmd, achievements, lore categories API, perf, dead code removal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
    <groupId>org.fourz.RVNKLore</groupId>
    <artifactId>RVNKLore</artifactId>
-   <version>1.0.20</version>
+   <version>1.0.21</version>
 
    <name>RVNKLore</name>
    <description></description>

--- a/src/main/java/org/fourz/RVNKLore/lore/player/PlayerRepository.java
+++ b/src/main/java/org/fourz/RVNKLore/lore/player/PlayerRepository.java
@@ -68,7 +68,7 @@ public class PlayerRepository implements IPlayerRepository {
             try (Connection conn = dbConnection.getConnection();
                  PreparedStatement stmt = conn.prepareStatement(sql)) {
                 stmt.setString(1, LoreType.PLAYER.name());
-                stmt.setString(2, "%\"player_uuid\":\"" + playerUuid.toString() + "\"%");
+                stmt.setString(2, "%\"player_uuid\"%" + playerUuid.toString() + "%");
 
                 try (ResultSet rs = stmt.executeQuery()) {
                     if (rs.next()) {
@@ -105,7 +105,7 @@ public class PlayerRepository implements IPlayerRepository {
             try (Connection conn = dbConnection.getConnection();
                  PreparedStatement stmt = conn.prepareStatement(sql)) {
                 stmt.setString(1, LoreType.PLAYER.name());
-                stmt.setString(2, "%\"player_uuid\":\"" + playerUuid.toString() + "\"%");
+                stmt.setString(2, "%\"player_uuid\"%" + playerUuid.toString() + "%");
 
                 try (ResultSet rs = stmt.executeQuery()) {
                     if (rs.next()) {
@@ -145,7 +145,7 @@ public class PlayerRepository implements IPlayerRepository {
             try (Connection conn = dbConnection.getConnection();
                  PreparedStatement stmt = conn.prepareStatement(sql)) {
                 stmt.setString(1, LoreType.PLAYER.name());
-                stmt.setString(2, "%\"player_uuid\":\"" + playerUuid.toString() + "\"%");
+                stmt.setString(2, "%\"player_uuid\"%" + playerUuid.toString() + "%");
 
                 try (ResultSet rs = stmt.executeQuery()) {
                     while (rs.next()) {
@@ -185,8 +185,8 @@ public class PlayerRepository implements IPlayerRepository {
             try (Connection conn = dbConnection.getConnection();
                  PreparedStatement stmt = conn.prepareStatement(sql)) {
                 stmt.setString(1, LoreType.PLAYER.name());
-                stmt.setString(2, "%\"player_uuid\":\"" + playerUuid.toString() + "\"%");
-                stmt.setString(3, "%\"entry_type\":\"" + entryType + "\"%");
+                stmt.setString(2, "%\"player_uuid\"%" + playerUuid.toString() + "%");
+                stmt.setString(3, "%\"entry_type\"%" + entryType + "%");
 
                 try (ResultSet rs = stmt.executeQuery()) {
                     while (rs.next()) {
@@ -238,8 +238,8 @@ public class PlayerRepository implements IPlayerRepository {
             try (Connection conn = dbConnection.getConnection();
                  PreparedStatement stmt = conn.prepareStatement(sql)) {
                 stmt.setString(1, LoreType.PLAYER.name());
-                stmt.setString(2, "%\"player_uuid\":\"" + playerUuid.toString() + "\"%");
-                stmt.setString(3, "%\"entry_type\":\"name_change\"%");
+                stmt.setString(2, "%\"player_uuid\"%" + playerUuid.toString() + "%");
+                stmt.setString(3, "%\"entry_type\"%name_change%");
 
                 try (ResultSet rs = stmt.executeQuery()) {
                     while (rs.next()) {


### PR DESCRIPTION
## Summary

- **Commands**: `/lore delete` with two-step confirmation; `/lore add` enhanced; `/lore prefs` console-safe message (#462)
- **Achievements**: `LoreDiscoveryEvent` wired to achievement system (#497); `setProgress()` and `grantAchievement()` now persist correctly (#496)
- **REST API**: `GET /lore/categories` endpoint (#391); search endpoint uses `LoreSearchService` with contains-matching + relevance scoring; `PagedLoreResponse.data` renamed to `entries`; stats double-load fixed; 400 on validation failure instead of 500 (#520); input validation + sanitization for submissions (#512)
- **Perf**: `ItemManager.initializeCache()` parallelized (#511); `getEntries()` and `getPlayerCollection()` pagination optimized (#508, #509)
- **UUID fix**: loosen UUID LIKE pattern to match any JSON spacing
- **Dynmap**: enhanced lore marker integration
- **Cleanup**: removed 14 dead code classes/files (#499-#507); removed duplicate `HandlerFactory`; removed unused worldedit-bukkit dep (#515); `PlayerQuitEvent` cleanup for cooldown/location maps (#510); replaced `HeadUtil` reflection with `PlayerProfile` API (#513)
- **Deps**: bumped RVNKCore to 1.4.5-alpha

## Test plan

- [ ] `/lore delete <id>` — requires confirmation, removes entry
- [ ] `/lore add` — enhanced flow works
- [ ] `GET /lore/categories` returns category list
- [ ] Lore discovery fires achievement progress
- [ ] `GET /lore/search?q=...` returns relevance-sorted results
- [ ] `mvn clean package` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)